### PR TITLE
Role removal problem fixed

### DIFF
--- a/cogs/reactionrole.py
+++ b/cogs/reactionrole.py
@@ -44,17 +44,6 @@ class ReactionRole(commands.Cog):
         rr = await models.ReactionRoles.get(emoji=payload.emoji)
         role = get(guild.roles, id=rr.role_id)
 
-        # Do not include "YMY Üyesi" role
-        if len(member.roles) - 1 >= self.MAX_ROLE:
-            await self._clear_reaction(payload, member)
-            return await self._send_message(
-                payload,
-                member,
-                "{}, you can take a max of `{}` roles.".format(
-                    member.mention, self.MAX_ROLE
-                ),
-            )
-
         if role.id in [r.id for r in member.roles]:
             await member.remove_roles(role)
             await self._clear_reaction(payload, member)
@@ -66,15 +55,26 @@ class ReactionRole(commands.Cog):
                 ),
             )
         else:
-            await member.add_roles(role)
-            await self._clear_reaction(payload, member)
-            await self._send_message(
-                payload,
-                member,
-                "`{}`, `{}` role has been __added__.".format(
-                    member, role.name
-                ),
-            )
+            # Do not include "YMY Üyesi" role
+            if len(member.roles) - 1 >= self.MAX_ROLE:
+                await self._clear_reaction(payload, member)
+                return await self._send_message(
+                    payload,
+                    member,
+                    "{}, you can take a max of `{}` roles.".format(
+                        member.mention, self.MAX_ROLE
+                    ),
+                )
+            else:
+                await member.add_roles(role)
+                await self._clear_reaction(payload, member)
+                await self._send_message(
+                    payload,
+                    member,
+                    "`{}`, `{}` role has been __added__.".format(
+                        member, role.name
+                    ),
+                )
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):


### PR DESCRIPTION
The bot used to warn me about having max number of roles even if I had clicked the role reaction that I already had had.
It should remove the role instead of warning me. I fixed that problem by replacing if else statements.

Zaten bende olan bir rolün reaksiyonuna tıklasam bile bot beni maksimum rol sayısına sahip olduğum için uyarıyordu.
Beni uyarmak yerine rolü alması gerekiyor. Bu problemi if else ifadelerinin yerini değiştirerek çözdüm.